### PR TITLE
Implemented the PDF conversion in the report page to get all the tran…

### DIFF
--- a/Spring/myfinance/pom.xml
+++ b/Spring/myfinance/pom.xml
@@ -72,6 +72,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
+            <version>5.5.13.2</version>
+        </dependency>
+        <!-- PDFBox for PDF generation -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.29</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Spring/myfinance/src/main/java/com/example/myfinance/Controller/TransactionsController.java
+++ b/Spring/myfinance/src/main/java/com/example/myfinance/Controller/TransactionsController.java
@@ -3,6 +3,8 @@ package com.example.myfinance.Controller;
 import com.example.myfinance.Transaction.Transaction.TransactionService;
 import com.example.myfinance.Transaction.Transaction.Transactions;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,4 +29,12 @@ public class TransactionsController {
     public void addTransaction(@RequestBody Transactions transactions){
         transactionService.addNewTransaction(transactions);
     }
+    @GetMapping(value = "/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    public ResponseEntity<byte[]> generatePdf() {
+        return transactionService.generatePdf();
+    }
+//    @PostMapping(value = "/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+//    public void generatePdf(){
+//        transactionService.generatePdf();
+//    }
 }

--- a/Spring/myfinance/src/main/java/com/example/myfinance/Transaction/Transaction/TransactionService.java
+++ b/Spring/myfinance/src/main/java/com/example/myfinance/Transaction/Transaction/TransactionService.java
@@ -1,10 +1,32 @@
 package com.example.myfinance.Transaction.Transaction;
 
+import com.itextpdf.text.Paragraph;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.pdf.PdfWriter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import java.io.ByteArrayOutputStream;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
@@ -20,8 +42,6 @@ public class TransactionService {
     public TransactionService(TransactionRepository transactionRepository) {
         this.transactionRepository = transactionRepository;
     }
-
-
 
 
     @GetMapping
@@ -52,4 +72,41 @@ public class TransactionService {
     public void addNewTransaction(Transactions transactions) {
         transactionRepository.save((transactions));
     }
+    public ResponseEntity<byte[]> generatePdf() {
+        try (PDDocument document = new PDDocument()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.beginText();
+                contentStream.setFont(PDType1Font.HELVETICA_BOLD, 14);
+                contentStream.newLineAtOffset(100, 700);
+                contentStream.showText("Transaction Report");
+                contentStream.newLineAtOffset(0, -20);
+
+                contentStream.setFont(PDType1Font.HELVETICA, 12);
+
+                List<Transactions> transactions = transactionRepository.findAll();
+                for (Transactions transaction : transactions) {
+                    contentStream.showText("Type: " + transaction.getType() + " | Amount: " + transaction.getAmount() + " | Date: " + transaction.getTransactionDate());
+                    contentStream.newLineAtOffset(0, -15);
+                }
+
+                contentStream.endText();
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            document.save(out);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_PDF);
+            headers.setContentDispositionFormData("attachment", "transactions.pdf");
+
+            return ResponseEntity.ok().headers(headers).body(out.toByteArray());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).build();
+        }
+    }
+
 }

--- a/Spring/myfinance/src/main/resources/templates/Components/Form.tsx
+++ b/Spring/myfinance/src/main/resources/templates/Components/Form.tsx
@@ -8,18 +8,19 @@ interface FormProps {
 }
 
 const Form = ({ input }: FormProps) => {
-    const [list, setList] = useState<Transactions[]>([]);
+    const [list, setList] = useState<string>([]);
 
 
-    function addToList(transaction: Transactions) {
-        const newList = [...list, transaction];
+    function addToList(items: string) {
+        const newList = [...list, items];
         setList(newList);
         input(newList);
     }
 
     return (
         <div>
-            {/* Render the list or other components here */}
+            <input id="idinput" placeholder="Enter items"></input>
+            <button onClick={() => addToList((document.getElementById("idinput") as HTMLInputElement).value)}>Add</button>
         </div>
     );
 };

--- a/Spring/myfinance/src/main/resources/templates/report.html
+++ b/Spring/myfinance/src/main/resources/templates/report.html
@@ -27,6 +27,10 @@
     </div>
 </div>
 
+<div>
+    <button onclick="generatePDF()">Download PDF</button>
+</div>
+
 <table border="1" id="tableId">
     <tr>
         <th>Type</th>
@@ -108,6 +112,19 @@
         // submitButton.addEventListener('click', () => {
         //     alert(`Transactions from ${minDate} to ${maxDate}`);
         // });
+    }
+    function generatePDF() {
+        fetch("http://localhost:8080/api/v1/transaction/pdf")
+            .then(response => response.blob())
+            .then(blob => {
+                const url = window.URL.createObjectURL(new Blob([blob]));
+                const link = document.createElement('a');
+                link.href = url;
+                link.setAttribute('download', 'transactions.pdf');
+                document.body.appendChild(link);
+                link.click();
+                link.parentNode.removeChild(link);
+            });
     }
 
     displayTransaction();


### PR DESCRIPTION
# Implement PDF Generation for Transaction Reports

## Description

This PR adds the ability to generate PDF documents for transaction reports using Apache PDFBox. Users can now download a PDF version of transaction details from the frontend.

## Changes Implemented

### 1. PDF Generation Using Apache PDFBox
- **New Method**: `generatePdf` in `TransactionService`
  - Creates a PDF document with transaction details.
  - Adds a page to the PDF and writes transaction information.
  - Returns the PDF as a byte array in the response.

### 2. New Endpoint in TransactionsController
- **New Endpoint**: `/pdf` in `TransactionsController`
  - Calls `generatePdf` from `TransactionService`.
  - Handles requests to generate and return the PDF document.

### 3. Frontend Changes
- **Button Added**: `report.html` - A button to trigger the PDF download.
- **JavaScript Function**: `generatePDF` function fetches the PDF and triggers the download on the frontend.

## Testing Instructions

1. **Backend Testing**
   - Call the `/pdf` endpoint and verify the PDF is generated and returned as expected.
   - Check that transaction details are accurately represented in the PDF content.

2. **Frontend Testing**
   - Open `report.html` in the app and click the new "Download PDF" button.
   - Confirm that clicking the button triggers a download of the PDF with correct transaction details.

## Notes
- Ensure Apache PDFBox dependencies are installed.
- Test the PDF document’s readability and formatting in different PDF viewers.
